### PR TITLE
fix TypeError: module object is not callable for cinder.py

### DIFF
--- a/oschecks/cinder.py
+++ b/oschecks/cinder.py
@@ -78,9 +78,9 @@ class Novautils(object):
     # now, after checking http://stackoverflow.com/a/16307378,
     # and http://stackoverflow.com/a/8778548 made my mind to this approach
     @staticmethod
-    def totimestamp(dt=None, epoch=datetime(1970, 1, 1)):
+    def totimestamp(dt=None, epoch=datetime.datetime(1970, 1, 1)):
         if not dt:
-            dt = datetime.utcnow()
+            dt = datetime.datetime.utcnow()
         td = dt - epoch
         # return td.total_seconds()
         return int((td.microseconds +


### PR DESCRIPTION
There is a bug in def totimestamp when datetime is called, the error is:

<pre>
Traceback (most recent call last):
  File "/usr/bin/oschecks-check_cinder_api", line 6, in <module>
    from oschecks.cinder import check_cinder_api
  File "/usr/lib/python2.7/site-packages/oschecks/cinder.py", line 66, in <module>
    class Novautils(object):
  File "/usr/lib/python2.7/site-packages/oschecks/cinder.py", line 81, in Novautils
    def totimestamp(dt=None, epoch=datetime(1970, 1, 1)):
TypeError: 'module' object is not callable
</pre>


This commit fix the error
