### PR TITLE
Fixed typos

### DIFF
--- a/oschecks/neutron.py
+++ b/oschecks/neutron.py
@@ -109,9 +109,9 @@ class Novautils(object):
     # now, after checking http://stackoverflow.com/a/16307378,
     # and http://stackoverflow.com/a/8778548 made my mind to this approach
     @staticmethod
-    def totimestamp(dt=None, epoch=datetime(1970, 1, 1)):
+    def totimestamp(dt=None, epoch=datetime.datetime(1970, 1, 1)):
         if not dt:
-            dt = datetime.utcnow()
+            dt = datetime.datetime.utcnow()
         td = dt - epoch
         # return td.total_seconds()
         return int((td.microseconds + (td.seconds + td.days * 24 * 3600)

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ console_scripts =
     oschecks-check_keystone_api = oschecks.keystone:check_keystone_api
     oschecks-check_neutron_api = oschecks.neutron:check_neutron_api
     oschecks-check_neutron_floating_ip = oschecks.neutron:check_neutron_floating_ip
-    schecks-check_nova_api = oschecks.nova:check_nova_api
+    oschecks-check_nova_api = oschecks.nova:check_nova_api
     oschecks-check_nova_instance = oschecks.nova:check_nova_instance
     oschecks-pacemaker_host_check = oschecks.pacemaker_host_check:pacemaker_host_check
 


### PR DESCRIPTION
Fixed a typo in setup.cfg and the datetime call in  oschecks/neutron.py.
